### PR TITLE
Adds support for runtime_parameters

### DIFF
--- a/module/wa/module.py
+++ b/module/wa/module.py
@@ -107,6 +107,7 @@ def run(i):
               (repetitions)         - statistical repetitions (default=1), for now statistical analysis is not used (TBD)
 
               (config)              - customize config
+              (runtime_parameters)  - runtime_parameters
               (params)              - workload params
               (scenario)            - use pre-defined scenario (see ck list wa-scenario)
 

--- a/script/process-wa/preprocess_workload.py
+++ b/script/process-wa/preprocess_workload.py
@@ -97,6 +97,8 @@ def ck_preprocess(i):
     r=ck.merge_dicts({'dict1':params, 'dict2':dp1})
     if r['return']>0: return r
 
+    runtime_parameters = dict(meta.get('runtime_parameters',{}))
+
     for k in sorted(dp):
         x=dp[k]
 
@@ -119,7 +121,7 @@ def ck_preprocess(i):
             params[k]=dv
 
     wname=meta['wa_alias']
-    agenda['workloads'].append({'name':wname, 'params': params})
+    agenda['workloads'].append({'name':wname, 'params': params, 'runtime_parameters': runtime_parameters})
 
     # Prepare agenda
     if 'global' not in agenda:


### PR DESCRIPTION
WA Agendas treat 'runtime_parameters' differently to other config information
so they need be specified separately.